### PR TITLE
Added section on advice and guidance for domestic abuse victims

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,25 @@
 						</div>
 					</div>
 				</div>
+				<div class="row">
+					<div class="column">
+						<div class="volunteering-cell purple">
+							<div class="first">Domesic Abuse</div>
+							<div class="second">
+								<p>Domestic abuse or violence is a crime and should be reported to the police. There
+									are also other organisations who can offer you help and support.</p>
+								<p>Here are some ways to safely get help in situations where you feel threatened and
+									trapped at home with an abuser, you want to report overtly because it's safe to do
+									so, or you want to report covertly to avoid repercussions.</p>
+								<a class="button purple" target="_blank" href="https://www.gov.uk/report-domestic-abuse">GOV.UK - report domestic abuse...</a>
+								<a class="button purple" target="_blank" href="https://www.nationaldahelpline.org.uk/">National domestic abuse helpline...</a>
+								<a class="button purple" target="_blank" href="https://www.womensaid.org.uk/covid-19-coronavirus-safety-advice-for-survivors/">Women's Aid safety advice...</a>
+							</div>
+						</div>
+					</div>
+					<div class="column">
+					</div>
+				</div>
 			</section>
 
 			<section class="container" id="contributing">

--- a/index.html
+++ b/index.html
@@ -109,13 +109,10 @@
 				<div class="row">
 					<div class="column">
 						<div class="volunteering-cell purple">
-							<div class="first">Domesic Abuse</div>
+							<div class="first">Safely report abuse</div>
 							<div class="second">
-								<p>Domestic abuse or violence is a crime and should be reported to the police. There
-									are also other organisations who can offer you help and support.</p>
-								<p>Here are some ways to safely get help in situations where you feel threatened and
-									trapped at home with an abuser, you want to report overtly because it's safe to do
-									so, or you want to report covertly to avoid repercussions.</p>
+								<p>If you are being abused, or if you know someone who is, there are organisations who can help and safe places to go.</p>
+								<p>Here are some ways you can get help if you are trapped at home with an abuser. You can report covertly if you need to.</p>
 								<a class="button purple" target="_blank" href="https://www.gov.uk/report-domestic-abuse">GOV.UK - report domestic abuse...</a>
 								<a class="button purple" target="_blank" href="https://www.nationaldahelpline.org.uk/">National domestic abuse helpline...</a>
 								<a class="button purple" target="_blank" href="https://www.womensaid.org.uk/covid-19-coronavirus-safety-advice-for-survivors/">Women's Aid safety advice...</a>

--- a/styles/main.css
+++ b/styles/main.css
@@ -54,6 +54,7 @@
 .volunteering-cell.red { border-color: #AD2121; }
 .volunteering-cell.cyan { border-color: #21ADAD; }
 .volunteering-cell.orange { border-color: #AD6621; }
+.volunteering-cell.purple { border-color: #862d86; }
 
 div.first {
 	text-align: center;
@@ -75,6 +76,7 @@ div.first,div.second {
 .button.green { background-color: #21AD21; border-color: #21AD21; }
 .button.cyan { background-color: #21ADAD; border-color: #21ADAD; }
 .button.orange { background-color: #AD6621; border-color: #AD6621; }
+.button.purple { background-color: #862d86; border-color: #862d86; }
 
 .volunteering-cell.green div.first {
 	background-color:  #21AD21;
@@ -107,4 +109,12 @@ div.first,div.second {
 .volunteering-cell.orange div.second {
 	background-color:  white;
 	color: #AD6621;
+}
+.volunteering-cell.purple div.first {
+	background-color:  #862d86;
+	color: white;
+}
+.volunteering-cell.purple div.second {
+	background-color:  white;
+	color: #862d86;
 }


### PR DESCRIPTION
I've had a go at coming up with the text for this section but am more than happy to make changes if there are any suggestions for improving it?

The link text for Women's Aid safety advice for survivors had to be shortened to keep the volunteer cell the same width as the others. I also added an additional link to the National Domestic Abuse Helpline which is run by the charity Refuge.

Edit: Title and content updated after feedback:

![image](https://user-images.githubusercontent.com/59448139/79045821-19567a80-7c05-11ea-9023-3a335d0302f1.png)
